### PR TITLE
Reattach button when the DOM updates

### DIFF
--- a/src/assets/js/github-button.js
+++ b/src/assets/js/github-button.js
@@ -17,7 +17,7 @@ function sendRequest(params, channelName, button) {
   var icon_emoji = params.emoji || ':slack:';
   var gitHubUrl = window.location.href;
   var repoName = gitHubUrl.split("/")[4];
-  var titleElement = document.querySelector('#partial-discussion-header > div.gh-header-show > h1 > span.js-issue-title')
+  var titleElement = document.querySelector('#partial-discussion-header > div.gh-header-show > h1 > span.js-issue-title');
   var title = repoName + " - " + titleElement.innerHTML.trim();
   var greenDiff = document.querySelector('#diffstat > span.text-green').innerHTML.trim();
   var redDiff = document.querySelector('#diffstat > span.text-red').innerHTML.trim();
@@ -47,7 +47,7 @@ function sendRequest(params, channelName, button) {
 
 function addButton(params, channelName) {
   var hasSentRequest = false;
-  var button = document.createElement("BUTTON")
+  var button = document.createElement("BUTTON");
   button.innerHTML = 'Send to ' + channelName;
   button.type = "button";
   button.className = "btn btn-sm";
@@ -57,8 +57,9 @@ function addButton(params, channelName) {
     }
   });
 
-  document.querySelector("#partial-discussion-header > div.gh-header-show > div")
-    .appendChild(button);
+  var headerActions = document.querySelector("#partial-discussion-header > div.gh-header-show > div");
+  headerActions.appendChild(button);
+  headerActions.addEventListener("DOMNodeRemovedFromDocument", attachSlackReviewButton);
 }
 
 function addButtons(params) {
@@ -68,4 +69,8 @@ function addButtons(params) {
   });
 }
 
-chrome.storage.local.get(null, addButtons);
+function attachSlackReviewButton() {
+  chrome.storage.local.get(null, addButtons);
+}
+
+attachSlackReviewButton();


### PR DESCRIPTION
Currently if you click on "Commits" or "Files changed", the slack review button goes away. This PR binds an event listener to the button parent so if the button(s) are removed, they'll immediately be added back in.

## Before
![loss](https://cloud.githubusercontent.com/assets/2350503/26270711/1a006c60-3cb2-11e7-8810-cc6af945da43.gif)

## After
![reattach](https://cloud.githubusercontent.com/assets/2350503/26270725/2f28ec98-3cb2-11e7-98c1-c227f5bf0422.gif)
